### PR TITLE
Discord + Dify: MCP practice tools, user stats, and discord_user_id in chatflow

### DIFF
--- a/src/application/ai/send-discord-channel-chat-message.use-case.ts
+++ b/src/application/ai/send-discord-channel-chat-message.use-case.ts
@@ -8,6 +8,7 @@ import { ConversationRepository } from '../../domain/repositories/conversation.r
 import { MessageRepository } from '../../domain/repositories/message.repository';
 import {
   DIFY_INPUT_DEVCRAFT_USER_ID_KEY,
+  DIFY_INPUT_DISCORD_USER_ID_KEY,
   DIFY_INPUT_MESSAGE_SOURCE_KEY,
   DIFY_MESSAGE_SOURCE_DISCORD,
 } from '../../infrastructure/llm/dify-chatflow.constants';
@@ -144,6 +145,7 @@ export class SendDiscordChannelChatMessageUseCase {
         difyInputOverrides: {
           [DIFY_INPUT_MESSAGE_SOURCE_KEY]: DIFY_MESSAGE_SOURCE_DISCORD,
           [DIFY_INPUT_DEVCRAFT_USER_ID_KEY]: 0,
+          [DIFY_INPUT_DISCORD_USER_ID_KEY]: discordUserId,
         },
       });
       if (out.difyConversationId && conversation.difyConversationId !== out.difyConversationId) {

--- a/src/application/knowledge/get-platform-stats.use-case.ts
+++ b/src/application/knowledge/get-platform-stats.use-case.ts
@@ -1,0 +1,81 @@
+import { Injectable } from '@nestjs/common';
+
+import { PrismaService } from '../../infrastructure/persistence/prisma/prisma.service';
+
+export type UserPracticeStatsInput = {
+  userId: number;
+  topicId?: string;
+  topicSlug?: string;
+};
+
+export type UserPracticeStatsResult = {
+  resolvedTopic: { id: string; slug: string; title: string } | null;
+  codeTaskAttemptsTotal: number;
+  codeTaskAttemptsValid: number;
+  codeTaskAttemptsLast7Days: number;
+  codeTaskAttemptsValidLast7Days: number;
+};
+
+@Injectable()
+export class GetPlatformStatsUseCase {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async execute(input: UserPracticeStatsInput): Promise<UserPracticeStatsResult> {
+    const sevenDaysAgo = new Date();
+    sevenDaysAgo.setDate(sevenDaysAgo.getDate() - 7);
+
+    const userWhere = { userId: input.userId };
+
+    let resolvedTopic: { id: string; slug: string; title: string } | null = null;
+    if (input.topicId != null && input.topicId !== '') {
+      const t = await this.prisma.topic.findUnique({
+        where: { id: input.topicId },
+        select: { id: true, slug: true, title: true },
+      });
+      resolvedTopic = t;
+    } else if (input.topicSlug != null && input.topicSlug.trim() !== '') {
+      const t = await this.prisma.topic.findUnique({
+        where: { slug: input.topicSlug.trim() },
+        select: { id: true, slug: true, title: true },
+      });
+      resolvedTopic = t;
+    }
+
+    const topicFilter = resolvedTopic ? { topicId: resolvedTopic.id } : {};
+
+    const [
+      codeTaskAttemptsTotal,
+      codeTaskAttemptsValid,
+      codeTaskAttemptsLast7Days,
+      codeTaskAttemptsValidLast7Days,
+    ] = await Promise.all([
+      this.prisma.codeTaskAttempt.count({ where: { ...userWhere, ...topicFilter } }),
+      this.prisma.codeTaskAttempt.count({
+        where: { ...userWhere, ...topicFilter, valid: true },
+      }),
+      this.prisma.codeTaskAttempt.count({
+        where: {
+          ...userWhere,
+          ...topicFilter,
+          createdAt: { gte: sevenDaysAgo },
+        },
+      }),
+      this.prisma.codeTaskAttempt.count({
+        where: {
+          ...userWhere,
+          ...topicFilter,
+          valid: true,
+          createdAt: { gte: sevenDaysAgo },
+        },
+      }),
+    ]);
+
+    return {
+      resolvedTopic,
+      codeTaskAttemptsTotal,
+      codeTaskAttemptsValid,
+      codeTaskAttemptsLast7Days,
+      codeTaskAttemptsValidLast7Days,
+    };
+  }
+}

--- a/src/discord-bot/dify/dify-chat-client.ts
+++ b/src/discord-bot/dify/dify-chat-client.ts
@@ -22,6 +22,7 @@ export class DifyChatClient {
       inputs: {
         message_source: 'discord',
         devcraft_user_id: '0',
+        discord_user_id: options.discordUserId,
       },
     };
     if (options.conversationId) {

--- a/src/infrastructure/discord/discord-practice-user.service.ts
+++ b/src/infrastructure/discord/discord-practice-user.service.ts
@@ -1,0 +1,64 @@
+import { Injectable, ServiceUnavailableException } from '@nestjs/common';
+import { Prisma } from '@prisma/client';
+
+import { PrismaService } from '../persistence/prisma/prisma.service';
+
+const SHADOW_EMAIL_PREFIX = 'discord-';
+const SHADOW_EMAIL_SUFFIX = '@discord.devcraft.internal';
+
+@Injectable()
+export class DiscordPracticeUserService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  private sharedSystemUserId(): number {
+    const raw = process.env.DISCORD_BOT_CONVERSATION_USER_ID?.trim();
+    if (!raw) {
+      throw new ServiceUnavailableException(
+        'DISCORD_BOT_CONVERSATION_USER_ID is required when DISCORD_CODE_TASK_USER_MODE=shared',
+      );
+    }
+    const n = parseInt(raw, 10);
+    if (!Number.isFinite(n) || n < 1) {
+      throw new ServiceUnavailableException('Invalid DISCORD_BOT_CONVERSATION_USER_ID');
+    }
+    return n;
+  }
+
+  private shadowEmail(discordUserId: string): string {
+    return `${SHADOW_EMAIL_PREFIX}${discordUserId}${SHADOW_EMAIL_SUFFIX}`;
+  }
+
+  async resolveUserId(discordUserId: string): Promise<number> {
+    const mode = (process.env.DISCORD_CODE_TASK_USER_MODE ?? 'shadow').trim().toLowerCase();
+    if (mode === 'shared') {
+      return this.sharedSystemUserId();
+    }
+
+    const email = this.shadowEmail(discordUserId);
+    const existing = await this.prisma.user.findUnique({ where: { email } });
+    if (existing) {
+      return existing.id;
+    }
+
+    try {
+      const created = await this.prisma.user.create({
+        data: {
+          name: 'Discord',
+          surname: `u${discordUserId}`,
+          email,
+          passwordHash: null,
+        },
+        select: { id: true },
+      });
+      return created.id;
+    } catch (e) {
+      if (e instanceof Prisma.PrismaClientKnownRequestError && e.code === 'P2002') {
+        const again = await this.prisma.user.findUnique({ where: { email } });
+        if (again) {
+          return again.id;
+        }
+      }
+      throw e;
+    }
+  }
+}

--- a/src/infrastructure/knowledge/di/knowledge-di.module.ts
+++ b/src/infrastructure/knowledge/di/knowledge-di.module.ts
@@ -1,6 +1,7 @@
 import { Module } from '@nestjs/common';
 
 import { GetKnowledgeTopicsUseCase } from '../../../application/knowledge/get-knowledge-topics.use-case';
+import { GetPlatformStatsUseCase } from '../../../application/knowledge/get-platform-stats.use-case';
 import { GetTopicCodeTasksUseCase } from '../../../application/knowledge/get-topic-code-tasks.use-case';
 import { GetTopicPreviewUseCase } from '../../../application/knowledge/get-topic-preview.use-case';
 import { GetTopicQuestionsUseCase } from '../../../application/knowledge/get-topic-questions.use-case';
@@ -29,6 +30,7 @@ import { PrismaTopicRepository } from '../../persistence/topic/prisma-topic.repo
     { provide: CodeTaskRepository, useClass: PrismaCodeTaskRepository },
     { provide: CodeTaskAttemptRepository, useClass: PrismaCodeTaskAttemptRepository },
     GetKnowledgeTopicsUseCase,
+    GetPlatformStatsUseCase,
     GetTopicCodeTasksUseCase,
     GetTopicPreviewUseCase,
     GetTopicQuestionsUseCase,
@@ -38,6 +40,7 @@ import { PrismaTopicRepository } from '../../persistence/topic/prisma-topic.repo
   ],
   exports: [
     GetKnowledgeTopicsUseCase,
+    GetPlatformStatsUseCase,
     GetTopicCodeTasksUseCase,
     GetTopicPreviewUseCase,
     GetTopicQuestionsUseCase,

--- a/src/infrastructure/llm/dify-chatflow.constants.ts
+++ b/src/infrastructure/llm/dify-chatflow.constants.ts
@@ -2,6 +2,7 @@ export const DIFY_CHAT_MESSAGES_PATH = '/chat-messages';
 export const DIFY_CHATFLOW_RESPONSE_MODE_BLOCKING = 'blocking';
 export const DIFY_END_USER_PREFIX = 'devcraft-';
 export const DIFY_INPUT_DEVCRAFT_USER_ID_KEY = 'devcraft_user_id';
+export const DIFY_INPUT_DISCORD_USER_ID_KEY = 'discord_user_id';
 export const DIFY_INPUT_MESSAGE_SOURCE_KEY = 'message_source';
 export const DIFY_MESSAGE_SOURCE_WEB = 'web';
 export const DIFY_MESSAGE_SOURCE_DISCORD = 'discord';

--- a/src/infrastructure/mcp/create-devcraft-mcp-server.ts
+++ b/src/infrastructure/mcp/create-devcraft-mcp-server.ts
@@ -3,23 +3,45 @@ import { HttpException } from '@nestjs/common';
 import * as z from 'zod/v4';
 
 import {
+  GET_PLATFORM_STATS_DISCORD_USER_ID_DESCRIPTION,
+  GET_PLATFORM_STATS_TOOL_DESCRIPTION,
+  GET_PLATFORM_STATS_TOOL_NAME,
+  GET_PLATFORM_STATS_TOOL_TITLE,
+  GET_PLATFORM_STATS_TOPIC_ID_DESCRIPTION,
+  GET_PLATFORM_STATS_TOPIC_SLUG_DESCRIPTION,
   MCP_ERROR_PREFIX,
   MCP_SERVER_DEFAULT_VERSION,
   MCP_SERVER_NAME,
   MCP_TEXT_CONTENT_TYPE,
-  TOPIC_SUMMARY_INCLUDE_SAMPLES_DESCRIPTION,
-  TOPIC_SUMMARY_TOOL_DESCRIPTION,
-  TOPIC_SUMMARY_TOOL_NAME,
-  TOPIC_SUMMARY_TOOL_TITLE,
-  TOPIC_SUMMARY_TOPIC_ID_DESCRIPTION,
-  TOPIC_SUMMARY_TOPIC_SLUG_DESCRIPTION,
+  SUBMIT_CODE_TASK_AI_CHECK_TOOL_DESCRIPTION,
+  SUBMIT_CODE_TASK_AI_CHECK_TOOL_NAME,
+  SUBMIT_CODE_TASK_AI_CHECK_TOOL_TITLE,
+  SUBMIT_CODE_TASK_CODE_BODY_DESCRIPTION,
+  SUBMIT_CODE_TASK_CODE_TASK_ID_DESCRIPTION,
+  SUBMIT_CODE_TASK_DISCORD_USER_ID_DESCRIPTION,
+  SUBMIT_CODE_TASK_TOPIC_ID_PARAM_DESCRIPTION,
+  TOPIC_CODE_TASKS_TOOL_DESCRIPTION,
+  TOPIC_CODE_TASKS_TOOL_NAME,
+  TOPIC_CODE_TASKS_TOOL_TITLE,
+  TOPIC_CODE_TASKS_TOPIC_ID_DESCRIPTION,
+  TOPIC_CODE_TASKS_TOPIC_SLUG_DESCRIPTION,
 } from './mcp.constants';
 
+const DEFAULT_MAX_CODE = 4000;
+const MCP_CODE_MAX_LENGTH = Number(process.env.AI_MAX_MESSAGE_LENGTH) || DEFAULT_MAX_CODE;
+
 export type DevCraftMcpServerOptions = {
-  getTopicSummary?: (input: {
+  getPlatformStats?: (input: {
+    discordUserId: string;
     topicId?: string;
     topicSlug?: string;
-    includeSamples?: boolean;
+  }) => Promise<string>;
+  getTopicCodeTasks?: (input: { topicId?: string; topicSlug?: string }) => Promise<string>;
+  submitCodeTaskAiCheck?: (input: {
+    discordUserId: string;
+    topicId: string;
+    codeTaskId: string;
+    code: string;
   }) => Promise<string>;
 };
 
@@ -32,25 +54,116 @@ export function createDevCraftMcpServer(options: DevCraftMcpServerOptions = {}):
     { capabilities: {} },
   );
 
-  if (options.getTopicSummary) {
-    const getSummary = options.getTopicSummary;
+  if (options.getPlatformStats) {
+    const getStats = options.getPlatformStats;
     server.registerTool(
-      TOPIC_SUMMARY_TOOL_NAME,
+      GET_PLATFORM_STATS_TOOL_NAME,
       {
-        title: TOPIC_SUMMARY_TOOL_TITLE,
-        description: TOPIC_SUMMARY_TOOL_DESCRIPTION,
+        title: GET_PLATFORM_STATS_TOOL_TITLE,
+        description: GET_PLATFORM_STATS_TOOL_DESCRIPTION,
         inputSchema: {
-          topicId: z.string().optional().describe(TOPIC_SUMMARY_TOPIC_ID_DESCRIPTION),
-          topicSlug: z.string().optional().describe(TOPIC_SUMMARY_TOPIC_SLUG_DESCRIPTION),
-          includeSamples: z
-            .boolean()
-            .optional()
-            .describe(TOPIC_SUMMARY_INCLUDE_SAMPLES_DESCRIPTION),
+          discordUserId: z.string().min(1).describe(GET_PLATFORM_STATS_DISCORD_USER_ID_DESCRIPTION),
+          topicId: z.string().optional().describe(GET_PLATFORM_STATS_TOPIC_ID_DESCRIPTION),
+          topicSlug: z.string().optional().describe(GET_PLATFORM_STATS_TOPIC_SLUG_DESCRIPTION),
         },
       },
       async (args) => {
         try {
-          const result = await getSummary(args);
+          const result = await getStats(args);
+          return {
+            content: [
+              {
+                type: MCP_TEXT_CONTENT_TYPE,
+                text: result,
+              },
+            ],
+          };
+        } catch (err: unknown) {
+          const message =
+            err instanceof HttpException
+              ? err.message
+              : err instanceof Error
+                ? err.message
+                : String(err);
+          return {
+            content: [
+              {
+                type: MCP_TEXT_CONTENT_TYPE,
+                text: `${MCP_ERROR_PREFIX} ${message}`,
+              },
+            ],
+            isError: true,
+          };
+        }
+      },
+    );
+  }
+
+  if (options.getTopicCodeTasks) {
+    const getTasks = options.getTopicCodeTasks;
+    server.registerTool(
+      TOPIC_CODE_TASKS_TOOL_NAME,
+      {
+        title: TOPIC_CODE_TASKS_TOOL_TITLE,
+        description: TOPIC_CODE_TASKS_TOOL_DESCRIPTION,
+        inputSchema: {
+          topicId: z.string().optional().describe(TOPIC_CODE_TASKS_TOPIC_ID_DESCRIPTION),
+          topicSlug: z.string().optional().describe(TOPIC_CODE_TASKS_TOPIC_SLUG_DESCRIPTION),
+        },
+      },
+      async (args) => {
+        try {
+          const result = await getTasks(args);
+          return {
+            content: [
+              {
+                type: MCP_TEXT_CONTENT_TYPE,
+                text: result,
+              },
+            ],
+          };
+        } catch (err: unknown) {
+          const message =
+            err instanceof HttpException
+              ? err.message
+              : err instanceof Error
+                ? err.message
+                : String(err);
+          return {
+            content: [
+              {
+                type: MCP_TEXT_CONTENT_TYPE,
+                text: `${MCP_ERROR_PREFIX} ${message}`,
+              },
+            ],
+            isError: true,
+          };
+        }
+      },
+    );
+  }
+
+  if (options.submitCodeTaskAiCheck) {
+    const submit = options.submitCodeTaskAiCheck;
+    server.registerTool(
+      SUBMIT_CODE_TASK_AI_CHECK_TOOL_NAME,
+      {
+        title: SUBMIT_CODE_TASK_AI_CHECK_TOOL_TITLE,
+        description: SUBMIT_CODE_TASK_AI_CHECK_TOOL_DESCRIPTION,
+        inputSchema: {
+          discordUserId: z.string().describe(SUBMIT_CODE_TASK_DISCORD_USER_ID_DESCRIPTION),
+          topicId: z.string().describe(SUBMIT_CODE_TASK_TOPIC_ID_PARAM_DESCRIPTION),
+          codeTaskId: z.string().describe(SUBMIT_CODE_TASK_CODE_TASK_ID_DESCRIPTION),
+          code: z
+            .string()
+            .min(1)
+            .max(MCP_CODE_MAX_LENGTH)
+            .describe(SUBMIT_CODE_TASK_CODE_BODY_DESCRIPTION),
+        },
+      },
+      async (args) => {
+        try {
+          const result = await submit(args);
           return {
             content: [
               {

--- a/src/infrastructure/mcp/mcp.constants.ts
+++ b/src/infrastructure/mcp/mcp.constants.ts
@@ -1,16 +1,36 @@
 export const MCP_SERVER_NAME = 'dev-craft-backend';
 export const MCP_SERVER_DEFAULT_VERSION = '0.0.1';
 
-export const TOPIC_SUMMARY_TOOL_NAME = 'get_topic_summary';
-export const TOPIC_SUMMARY_TOOL_TITLE = 'Get topic summary';
-export const TOPIC_SUMMARY_TOOL_DESCRIPTION =
-  'Returns structured learning topic summary from DevCraft knowledge data. Use topicId or topicSlug for a specific topic, or call without both to list available topics.';
-export const TOPIC_SUMMARY_TOPIC_ID_DESCRIPTION =
-  'Optional topic identifier (topics.id UUID) to get a specific topic summary.';
-export const TOPIC_SUMMARY_TOPIC_SLUG_DESCRIPTION =
-  'Optional topic slug (topics.slug) to get a specific topic summary.';
-export const TOPIC_SUMMARY_INCLUDE_SAMPLES_DESCRIPTION =
-  'When true, include example question prompts and code-task titles in the result.';
+export const KNOWLEDGE_TOPIC_ID_DESCRIPTION = 'Optional topic identifier (topics.id UUID).';
+export const KNOWLEDGE_TOPIC_SLUG_DESCRIPTION = 'Optional topic slug (topics.slug).';
+
+export const GET_PLATFORM_STATS_TOOL_NAME = 'get_platform_stats';
+export const GET_PLATFORM_STATS_TOOL_TITLE = 'Get user practice stats';
+export const GET_PLATFORM_STATS_TOOL_DESCRIPTION =
+  'Returns practice statistics for a single user (resolved via Discord snowflake like submit_code_task_ai_check): code-task AI_CHECK attempts only (totals, valid rate, last 7 days). Question-quiz stats are not included. Optionally restrict to one topic with topicId or topicSlug. No other users or global aggregates.';
+export const GET_PLATFORM_STATS_DISCORD_USER_ID_DESCRIPTION =
+  'Discord user snowflake (numeric string). Same attribution as submit_code_task_ai_check (shadow or shared user mode).';
+export const GET_PLATFORM_STATS_TOPIC_ID_DESCRIPTION = 'Optional: limit stats to this topic UUID.';
+export const GET_PLATFORM_STATS_TOPIC_SLUG_DESCRIPTION =
+  'Optional: limit stats to this topic slug.';
+
+export const TOPIC_CODE_TASKS_TOOL_NAME = 'get_topic_code_tasks';
+export const TOPIC_CODE_TASKS_TOOL_TITLE = 'Get topic code tasks';
+export const TOPIC_CODE_TASKS_TOOL_DESCRIPTION =
+  'Returns code practice tasks for a DevCraft topic from the database (id, title, description, task type, order). Does not expose reference solutions. Pass topicId or topicSlug; if both omitted, returns the topic catalog.';
+export const TOPIC_CODE_TASKS_TOPIC_ID_DESCRIPTION = KNOWLEDGE_TOPIC_ID_DESCRIPTION;
+export const TOPIC_CODE_TASKS_TOPIC_SLUG_DESCRIPTION = KNOWLEDGE_TOPIC_SLUG_DESCRIPTION;
+
+export const SUBMIT_CODE_TASK_AI_CHECK_TOOL_NAME = 'submit_code_task_ai_check';
+export const SUBMIT_CODE_TASK_AI_CHECK_TOOL_TITLE = 'Submit code task AI check';
+export const SUBMIT_CODE_TASK_AI_CHECK_TOOL_DESCRIPTION =
+  'Runs the same DevCraft AI_CHECK pipeline as the web app: compares user code to the reference, returns valid/hints/justification, and persists a code_task_attempt. Use with discordUserId (snowflake), topicId, codeTaskId (UUIDs), and code.';
+export const SUBMIT_CODE_TASK_DISCORD_USER_ID_DESCRIPTION =
+  'Discord user snowflake (numeric string). Used to attribute the attempt (shadow User per id, or shared mode via env).';
+export const SUBMIT_CODE_TASK_TOPIC_ID_PARAM_DESCRIPTION = 'Topic UUID (topics.id).';
+export const SUBMIT_CODE_TASK_CODE_TASK_ID_DESCRIPTION = 'Code task UUID (code_tasks.id).';
+export const SUBMIT_CODE_TASK_CODE_BODY_DESCRIPTION =
+  "User's submitted source code for the AI_CHECK task.";
 
 export const MCP_TEXT_CONTENT_TYPE = 'text';
 export const MCP_ERROR_PREFIX = 'Error:';

--- a/src/presentation/api/internal/internal.module.ts
+++ b/src/presentation/api/internal/internal.module.ts
@@ -1,10 +1,15 @@
 import { Module } from '@nestjs/common';
 
 import { AiDiModule } from '../../../infrastructure/ai/di/ai-di.module';
+import { DiscordPracticeUserService } from '../../../infrastructure/discord/discord-practice-user.service';
+import { KnowledgeDiModule } from '../../../infrastructure/knowledge/di/knowledge-di.module';
+import { PrismaModule } from '../../../infrastructure/persistence/prisma/prisma.module';
 import { InternalDiscordChatController } from './internal-discord-chat.controller';
 
 @Module({
-  imports: [AiDiModule],
+  imports: [AiDiModule, KnowledgeDiModule, PrismaModule],
   controllers: [InternalDiscordChatController],
+  providers: [DiscordPracticeUserService],
+  exports: [DiscordPracticeUserService],
 })
 export class InternalModule {}

--- a/src/presentation/api/mcp/mcp.controller.ts
+++ b/src/presentation/api/mcp/mcp.controller.ts
@@ -4,7 +4,12 @@ import { SkipThrottle } from '@nestjs/throttler';
 import type { Request, Response } from 'express';
 
 import { GetKnowledgeTopicsUseCase } from '../../../application/knowledge/get-knowledge-topics.use-case';
-import { GetTopicPreviewUseCase } from '../../../application/knowledge/get-topic-preview.use-case';
+import type { UserPracticeStatsResult } from '../../../application/knowledge/get-platform-stats.use-case';
+import { GetPlatformStatsUseCase } from '../../../application/knowledge/get-platform-stats.use-case';
+import { GetTopicCodeTasksUseCase } from '../../../application/knowledge/get-topic-code-tasks.use-case';
+import { SubmitCodeTaskAiCheckUseCase } from '../../../application/knowledge/submit-code-task-ai-check.use-case';
+import type { TopicCodeTasks } from '../../../domain/repositories/topic.repository';
+import { DiscordPracticeUserService } from '../../../infrastructure/discord/discord-practice-user.service';
 import { createDevCraftMcpServer } from '../../../infrastructure/mcp/create-devcraft-mcp-server';
 @Controller('mcp')
 @SkipThrottle()
@@ -13,7 +18,10 @@ export class McpController {
 
   constructor(
     private readonly getKnowledgeTopicsUseCase: GetKnowledgeTopicsUseCase,
-    private readonly getTopicPreviewUseCase: GetTopicPreviewUseCase,
+    private readonly getPlatformStatsUseCase: GetPlatformStatsUseCase,
+    private readonly getTopicCodeTasksUseCase: GetTopicCodeTasksUseCase,
+    private readonly submitCodeTaskAiCheckUseCase: SubmitCodeTaskAiCheckUseCase,
+    private readonly discordPracticeUserService: DiscordPracticeUserService,
   ) {}
 
   private formatTopicsList(
@@ -32,35 +40,42 @@ export class McpController {
     return lines.join('\n');
   }
 
-  private formatTopicSummary(input: {
-    preview: Awaited<ReturnType<GetTopicPreviewUseCase['execute']>>;
-    includeSamples: boolean;
-  }): string {
-    const { preview, includeSamples } = input;
+  private formatUserPracticeStatsText(s: UserPracticeStatsResult): string {
+    const pct = (num: number, den: number): string =>
+      den === 0 ? 'n/a' : `${((100 * num) / den).toFixed(1)}%`;
+
+    const scope =
+      s.resolvedTopic != null
+        ? `Тема: ${s.resolvedTopic.title} (slug: ${s.resolvedTopic.slug})`
+        : 'Все темы';
+
     const lines = [
-      `Topic: ${preview.topic.title}`,
-      `Slug: ${preview.topic.slug}`,
-      `Topic ID: ${preview.topic.id}`,
-      `Description: ${preview.topic.description ?? 'No description'}`,
-      `Questions count: ${preview.questions.length}`,
-      `Code tasks count: ${preview.codeTasks.length}`,
+      'Статистика практики DevCraft (только задания с AI-проверкой кода).',
+      `Область: ${scope}`,
+      '',
+      `За всё время — попыток: ${s.codeTaskAttemptsTotal}, успешных (valid): ${s.codeTaskAttemptsValid}, доля успеха: ${pct(s.codeTaskAttemptsValid, s.codeTaskAttemptsTotal)}`,
+      `Последние 7 дней — попыток: ${s.codeTaskAttemptsLast7Days}, успешных: ${s.codeTaskAttemptsValidLast7Days}, доля успеха: ${pct(s.codeTaskAttemptsValidLast7Days, s.codeTaskAttemptsLast7Days)}`,
     ];
 
-    if (includeSamples) {
-      if (preview.questions.length) {
-        lines.push('Sample question prompts:');
-        for (const question of preview.questions.slice(0, 3)) {
-          lines.push(`- ${question.prompt}`);
-        }
-      }
-      if (preview.codeTasks.length) {
-        lines.push('Sample code-task titles:');
-        for (const task of preview.codeTasks.slice(0, 3)) {
-          lines.push(`- ${task.title}`);
-        }
-      }
-    }
+    return lines.join('\n');
+  }
 
+  private formatTopicCodeTasksText(data: TopicCodeTasks): string {
+    const lines = [
+      `Topic: ${data.topic.title}`,
+      `Slug: ${data.topic.slug}`,
+      `Topic ID: ${data.topic.id}`,
+      `Code tasks (${data.codeTasks.length}):`,
+    ];
+    let i = 1;
+    for (const task of data.codeTasks) {
+      lines.push('');
+      lines.push(`${i}. [${task.taskType}] ${task.title}`);
+      lines.push(`   Task ID: ${task.id}`);
+      lines.push(`   Order: ${task.order}`);
+      lines.push(`   Description:\n${task.description}`);
+      i += 1;
+    }
     return lines.join('\n');
   }
 
@@ -76,7 +91,24 @@ export class McpController {
     }
 
     const mcpServer = createDevCraftMcpServer({
-      getTopicSummary: async ({ topicId, topicSlug, includeSamples }) => {
+      getPlatformStats: async ({ discordUserId, topicId, topicSlug }) => {
+        const userId = await this.discordPracticeUserService.resolveUserId(discordUserId);
+        const stats = await this.getPlatformStatsUseCase.execute({
+          userId,
+          topicId,
+          topicSlug,
+        });
+        let text = this.formatUserPracticeStatsText(stats);
+        const filter =
+          (topicId != null && topicId.trim() !== '') ||
+          (topicSlug != null && topicSlug.trim() !== '');
+        if (filter && stats.resolvedTopic == null) {
+          text +=
+            '\n\nNote: topicId/topicSlug did not match any topic; stats are for all topics for this user.';
+        }
+        return text;
+      },
+      getTopicCodeTasks: async ({ topicId, topicSlug }) => {
         const topics = await this.getKnowledgeTopicsUseCase.execute();
         const resolvedTopic =
           topicId != null
@@ -86,14 +118,33 @@ export class McpController {
               : null;
 
         if (!resolvedTopic) {
-          return this.formatTopicsList(topics);
+          const catalog = this.formatTopicsList(topics);
+          return `Specify topicId or topicSlug to list code tasks.\n\n${catalog}`;
         }
 
-        const preview = await this.getTopicPreviewUseCase.execute(resolvedTopic.id);
-        return this.formatTopicSummary({
-          preview,
-          includeSamples: includeSamples === true,
+        const data = await this.getTopicCodeTasksUseCase.execute(resolvedTopic.id);
+        return this.formatTopicCodeTasksText(data);
+      },
+      submitCodeTaskAiCheck: async ({ discordUserId, topicId, codeTaskId, code }) => {
+        const userId = await this.discordPracticeUserService.resolveUserId(discordUserId);
+        const out = await this.submitCodeTaskAiCheckUseCase.execute({
+          userId,
+          topicId,
+          codeTaskId,
+          code,
         });
+        return JSON.stringify(
+          {
+            valid: out.valid,
+            attemptId: out.attemptId,
+            codeTaskId: out.codeTaskId,
+            hints: out.hints,
+            justification: out.justification,
+            improvements: out.improvements,
+          },
+          null,
+          2,
+        );
       },
     });
     const transport = new StreamableHTTPServerTransport({

--- a/src/presentation/api/mcp/mcp.module.ts
+++ b/src/presentation/api/mcp/mcp.module.ts
@@ -1,10 +1,11 @@
 import { Module } from '@nestjs/common';
 
 import { KnowledgeDiModule } from '../../../infrastructure/knowledge/di/knowledge-di.module';
+import { InternalModule } from '../internal/internal.module';
 import { McpController } from './mcp.controller';
 
 @Module({
-  imports: [KnowledgeDiModule],
+  imports: [KnowledgeDiModule, InternalModule],
   controllers: [McpController],
 })
 export class McpModule {}


### PR DESCRIPTION
### Summary

- Pass **`discord_user_id`** into Dify from the Discord chat path (`SendDiscordChannelChatMessageUseCase`, `DifyChatClient`).
- **MCP** (`/mcp`): tools **`get_topic_code_tasks`**, **`submit_code_task_ai_check`**, **`get_platform_stats`** (per Discord user, code-task AI attempts only); drop **`get_topic_summary`**.
- **`DiscordPracticeUserService`**: map snowflake - `users.id` (**shadow** default, **shared** via env); exported from **`InternalModule`**, consumed by **`McpModule`** / **`McpController`**.
- **`GetPlatformStatsUseCase`** + DI registration.